### PR TITLE
sphinxcontrib-websupport 2.0.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ test:
   requires:
     - pip
     - pytest
+    - defusedxml
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,47 +1,57 @@
 {% set name = "sphinxcontrib-websupport" %}
-{% set version = "1.2.4" %}
-{% set sha256 = "4edf0223a0685a7c485ae5a156b6f529ba1ee481a1417817935b20bde1956232" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 0b7367d3bac6454b1f97e42aa8c4d4d4a1b756d525fc726ebbe5571e033e79cd
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<39]
 
 requirements:
   host:
     - pip
+    - python
     - setuptools
     - wheel
-    - python
-    - setuptools
-    - sphinxcontrib
+    - flit-core >=3.7
   run:
     - python
-    - sphinxcontrib
+    - jinja2
+    - sphinx >=5
+    - sphinxcontrib-serializinghtml
 
 test:
+  source_files:
+    - tests
   imports:
     - sphinxcontrib
+    - sphinxcontrib.serializinghtml
+    - sphinxcontrib.websupport
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v tests
 
 about:
-  home: https://pypi.python.org/pypi/sphinxcontrib-websupport
+  home: https://pypi.org/pypi/sphinxcontrib-websupport
   license: BSD-2-Clause
   license_family: BSD
-  license_file: LICENSE
+  license_file: LICENCE.rst
   summary: Sphinx API for Web Apps
   description: |
     sphinxcontrib-websupport provides a Python API to easily integrate
     Sphinx documentation into your Web application
-  doc_url: http://www.sphinx-doc.org/en/stable/
+  doc_url: https://www.sphinx-doc.org
   dev_url: https://github.com/sphinx-doc/sphinxcontrib-websupport
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,6 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
     - flit-core >=3.7
   run:
     - python


### PR DESCRIPTION
sphinxcontrib-websupport 2.0.0 

**Destination channel:** Defaults

### Links

- [PKG-7825]
- dev_url:        https://github.com/sphinx-doc/sphinxcontrib-websupport/tree/2.0.0
- conda_forge:    https://github.com/conda-forge/sphinxcontrib-websupport-feedstock
- pypi:           https://pypi.org/project/sphinxcontrib-websupport/2.0.0
- pypi inspector: https://inspector.pypi.io/project/sphinxcontrib-websupport/2.0.0

### Explanation of changes:

- new version number


[PKG-7825]: https://anaconda.atlassian.net/browse/PKG-7825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ